### PR TITLE
<fix>(권한 에러) : 어르신 로그아웃시 403 에러 발생하던 문제 해결 후 푸시합니다.

### DIFF
--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -2,7 +2,8 @@
  * 홈 화면 (로그인 후 메인 화면)
  * 어르신과 보호자 계정에 따라 다른 화면을 보여줍니다.
  */
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useRouter } from 'expo-router';
 import { useAuthStore } from '../store/authStore';
 import { ElderlyHomeScreen } from './ElderlyHomeScreen';
 import { GuardianHomeScreen } from './GuardianHomeScreen';
@@ -10,9 +11,22 @@ import { UserRole } from '../types';
 
 export const HomeScreen = () => {
   const { user } = useAuthStore();
+  const router = useRouter();
+
+  // 사용자가 로그인하지 않은 경우 로그인 화면으로 리다이렉트
+  useEffect(() => {
+    if (!user) {
+      router.replace('/login');
+    }
+  }, [user, router]);
+
+  // 사용자가 로그인하지 않은 경우 아무것도 렌더링하지 않음
+  if (!user) {
+    return null;
+  }
 
   // 사용자 role에 따라 다른 화면 렌더링
-  if (user?.role === UserRole.ELDERLY) {
+  if (user.role === UserRole.ELDERLY) {
     return <ElderlyHomeScreen />;
   }
 

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -56,8 +56,10 @@ export const useAuthStore = create<AuthState>((set) => ({
   logout: async () => {
     try {
       set({ isLoading: true });
+      // 먼저 사용자 정보를 즉시 null로 설정
+      set({ user: null });
       await authApi.logout();
-      set({ user: null, isLoading: false, error: null });
+      set({ isLoading: false, error: null });
     } catch (error) {
       set({ isLoading: false });
       throw error;


### PR DESCRIPTION
authstore , HomeScreen 파일 수정 완료 어르신 로그아웃 시 바로 모든 정보가 null 처리 되지않고 자동 리다이렉트가 보호자 화면으로 설정되어 있어서 문제 발생 해당 부분 수정 후 푸시합니다. 